### PR TITLE
fix(hooks): SessionStartフックを正しいネスト構造に修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,8 +17,12 @@
 	"hooks": {
 		"SessionStart": [
 			{
-				"type": "command",
-				"command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-skills.sh"
+				"hooks": [
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-skills.sh"
+					}
+				]
 			}
 		]
 	}


### PR DESCRIPTION
SessionStartの登録がマッチャー直下にcommandを置く誤った構造になっており、
Claude Codeがフックを認識せずsetup-skills.shが実行されていなかった。
hooks配列でラップする正しい形式に修正し、セッション開始時に
ryotaKFC/ryotaKFCのスキルが取得されるようにする。

Fixes #44

https://claude.ai/code/session_014ZzkULdMw4C8CfJoGBJJgF