### PR TITLE
feat: コードレビューをCopilotからClaudeに移行 (#42)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [develop]
+
+jobs:
+  claude-review:
+    name: claude review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            このプルリクエストをレビューしてください。
+
+            リポジトリ: ${{ github.repository }}
+            PR番号: ${{ github.event.pull_request.number }}
+
+            レビュー方針はリポジトリ直下の `CLAUDE.md` に従ってください。
+            重要な点:
+            - レビューコメントはすべて日本語で記述する
+            - 重大な問題（バグ・セキュリティ・パフォーマンス）を優先し、軽微なスタイル指摘は最小限にとどめる
+            - フォーマット（インデント・クォート・import 順序）は Biome が自動管理するため指摘しない
+
+            変更内容を確認し、問題のある箇所には `mcp__github_inline_comment__create_inline_comment`
+            でインラインコメントを付けてください。指摘が無い場合や全体的な所感は
+            `gh pr comment` でまとめて投稿してください。
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    name: claude
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,8 @@
-# GitHub Copilot レビュー指示
+# Claude コードレビュー指示
+
+このリポジトリのコードレビュー（GitHub Actions の `claude-code-review` ワークフロー、
+および `@claude` メンション）で従う方針をまとめる。ローカルの Claude Code でも
+プロジェクト共通の規約として参照する。
 
 ## 基本方針
 


### PR DESCRIPTION
- anthropics/claude-code-action による自動PRレビューワークフローを追加
- @claude メンションで対話できるワークフローを追加
- レビュー方針を copilot-instructions.md から CLAUDE.md へ移行
- Copilot 専用の指示ファイルを削除

https://claude.ai/code/session_01NrfsPG5Uei39m585AV7Roz