### PR TITLE
Remove test skill and fix global skill installation

### DIFF
--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,8 +1,0 @@
----
-name: test
-description: test skills
----
-
-
-以下を出力してください
-Hello world!

--- a/.claude/skills/test
+++ b/.claude/skills/test
@@ -1,1 +1,0 @@
-../../.agents/skills/test

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             このプルリクエストをレビューしてください。
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/scripts/setup-skills.sh
+++ b/scripts/setup-skills.sh
@@ -7,8 +7,11 @@ echo "CLAUDE_PROJECT_DIR=${CLAUDE_PROJECT_DIR}" >&2
 
 [ "$CLAUDE_CODE_REMOTE" != "true" ] && { echo "SKIP: not remote" >&2; exit 0; }
 
-echo "Running: npx skills add ryotaKFC/ryotaKFC --all -a claude-code -y" >&2
-npx skills add ryotaKFC/ryotaKFC --all -a claude-code -y
+# 個人用 skills は user スコープ (-g/--global, ~/.claude/skills) へインストールする。
+# プロジェクト配下にインストールするとリポジトリに展開され git に追跡されてしまうため
+# (issue #47)、必ずグローバルへ入れてリポジトリを汚さないようにする。
+echo "Running: npx skills add ryotaKFC/ryotaKFC --global --skill '*' -a claude-code -y" >&2
+npx skills add ryotaKFC/ryotaKFC --global --skill '*' -a claude-code -y
 echo "=== setup-skills.sh DONE ===" >&2
 
 exit 0

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -18,12 +18,6 @@
 			"sourceType": "github",
 			"skillPath": "skills/engineering/grill-with-docs/SKILL.md",
 			"computedHash": "eb0e91e84277283dc2b23ed544399e53afd6b5287e5b6929f25fe8aa608e164b"
-		},
-		"test": {
-			"source": "ryotaKFC/ryotaKFC",
-			"sourceType": "github",
-			"skillPath": "skills/test/SKILL.md",
-			"computedHash": "44712480fd84f09002770716f52f0c8083eb229c377d13bc1559e71e8b0de14e"
 		}
 	}
 }


### PR DESCRIPTION
## 概要
テスト用スキルを削除し、スキルのインストール方法をプロジェクトスコープからグローバルスコープに変更します。

## 主な変更

- **テスト用スキルの削除**: `.agents/skills/test/SKILL.md` と `.claude/skills/test` シンボリックリンクを削除
- **skills-lock.json の更新**: テスト用スキルのエントリを削除
- **スキルインストール方法の改善**: `scripts/setup-skills.sh` で `npx skills add` コマンドを以下のように変更
  - `--all` フラグを `--global --skill '*'` に変更
  - プロジェクトディレクトリではなく、ユーザーのグローバルスコープ (`~/.claude/skills`) にインストール

## 実装の詳細

プロジェクト配下にスキルをインストールするとリポジトリに展開され、git に追跡されてしまう問題（issue #47）を解決するため、グローバルスコープへのインストールに統一しました。これにより、リポジトリを汚さずにスキルを管理できます。

https://claude.ai/code/session_01WaxSEvEH2gQZTuZb8hxfJz