### PR TITLE
developの内容をmainに同期 (PR #51のコンフリクト解消)

### DIFF
--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,8 +1,0 @@
----
-name: test
-description: test skills
----
-
-
-以下を出力してください
-Hello world!

--- a/.claude/skills/test
+++ b/.claude/skills/test
@@ -1,1 +1,0 @@
-../../.agents/skills/test

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             このプルリクエストをレビューしてください。
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/scripts/setup-skills.sh
+++ b/scripts/setup-skills.sh
@@ -7,8 +7,11 @@ echo "CLAUDE_PROJECT_DIR=${CLAUDE_PROJECT_DIR}" >&2
 
 [ "$CLAUDE_CODE_REMOTE" != "true" ] && { echo "SKIP: not remote" >&2; exit 0; }
 
-echo "Running: npx skills add ryotaKFC/ryotaKFC --all -a claude-code -y" >&2
-npx skills add ryotaKFC/ryotaKFC --all -a claude-code -y
+# 個人用 skills は user スコープ (-g/--global, ~/.claude/skills) へインストールする。
+# プロジェクト配下にインストールするとリポジトリに展開され git に追跡されてしまうため
+# (issue #47)、必ずグローバルへ入れてリポジトリを汚さないようにする。
+echo "Running: npx skills add ryotaKFC/ryotaKFC --global --skill '*' -a claude-code -y" >&2
+npx skills add ryotaKFC/ryotaKFC --global --skill '*' -a claude-code -y
 echo "=== setup-skills.sh DONE ===" >&2
 
 exit 0

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -18,12 +18,6 @@
 			"sourceType": "github",
 			"skillPath": "skills/engineering/grill-with-docs/SKILL.md",
 			"computedHash": "eb0e91e84277283dc2b23ed544399e53afd6b5287e5b6929f25fe8aa608e164b"
-		},
-		"test": {
-			"source": "ryotaKFC/ryotaKFC",
-			"sourceType": "github",
-			"skillPath": "skills/test/SKILL.md",
-			"computedHash": "44712480fd84f09002770716f52f0c8083eb229c377d13bc1559e71e8b0de14e"
 		}
 	}
 }


### PR DESCRIPTION
## 概要

PR #51 (develop -> main) が、過去のsquash mergeにより main と develop の共通祖先が
ずれてしまったことで `.github/workflows/claude.yml` 等4ファイルで
add/add コンフリクトとなり mergeable: CONFLICTING の状態になっていた。

develop は直接push禁止 + squash mergeのみのため、merge commitでの解消結果を
develop に反映できない。そこで main からブランチを切り、develop をmergeして
コンフリクトをdevelop側の内容で解消したものをこのPRとして提案する。

## 内容

- develop の最新内容 (`3c30b28`) と完全に一致するように main を更新
  - `.github/workflows/claude.yml` / `claude-code-review.yml`: oauthトークン認証
  - `scripts/setup-skills.sh`: 個人用skillsをグローバルインストール
  - `skills-lock.json`: testスキルのエントリを削除
  - 復活していた `.agents/skills/test/`, `.claude/skills/test` を削除

マージ後、PR #51 はコンフリクトが解消されるか、差分が無くなりクローズ可能になるはず。

🤖 Generated with [Claude Code](https://claude.ai/code/session_01WaxSEvEH2gQZTuZb8hxfJz)