### PR TITLE
ci: add guard to allow only develop -> main merges

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,24 @@
+name: Guard main branch
+
+# main へは develop からのみマージできるようにするためのガード。
+# feat ブランチが develop を飛ばして main に直接マージされるのを防ぐ
+# （想定フロー: feat -> develop -> main）。
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  guard:
+    name: Only allow develop -> main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        env:
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |
+          echo "PR head branch: $HEAD_BRANCH"
+          if [ "$HEAD_BRANCH" != "develop" ]; then
+            echo "::error::main へは develop からのみマージできます（フロー: feat -> develop -> main）。現在の head ブランチ: $HEAD_BRANCH"
+            exit 1
+          fi
+          echo "develop -> main のマージです。OK"


### PR DESCRIPTION
main 宛ての PR で head ブランチが develop 以外なら CI を失敗させ、
feat ブランチが develop を飛ばして main に直接マージされるのを防ぐ。

Closes #57

https://claude.ai/code/session_017bsymdwqxpDXrRnhh6uyKj