### PR TITLE
Add Supabase database schema and type definitions for lobbies

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,7 +1,8 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "./database.types";
 
 export function createClient() {
-	return createBrowserClient(
+	return createBrowserClient<Database>(
 		// biome-ignore lint/style/noNonNullAssertion: env vars are required at runtime
 		process.env.NEXT_PUBLIC_SUPABASE_URL!,
 		// biome-ignore lint/style/noNonNullAssertion: env vars are required at runtime

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1,0 +1,68 @@
+export type Json =
+	| string
+	| number
+	| boolean
+	| null
+	| { [key: string]: Json | undefined }
+	| Json[];
+
+export type Database = {
+	public: {
+		Tables: {
+			lobbies: {
+				Row: {
+					lobby_id: string;
+					lobby_name: string;
+					start_time: string;
+					study_min: number;
+					break_min: number;
+					is_private: boolean;
+					is_in_school: boolean;
+					member_count: number;
+					last_activity_at: string;
+					created_at: string;
+				};
+				Insert: {
+					lobby_id?: string;
+					lobby_name: string;
+					start_time: string;
+					study_min: number;
+					break_min: number;
+					is_private?: boolean;
+					is_in_school?: boolean;
+					member_count?: number;
+					last_activity_at?: string;
+					created_at?: string;
+				};
+				Update: {
+					lobby_id?: string;
+					lobby_name?: string;
+					start_time?: string;
+					study_min?: number;
+					break_min?: number;
+					is_private?: boolean;
+					is_in_school?: boolean;
+					member_count?: number;
+					last_activity_at?: string;
+					created_at?: string;
+				};
+				Relationships: [];
+			};
+		};
+		Views: Record<never, never>;
+		Functions: Record<never, never>;
+		Enums: Record<never, never>;
+		CompositeTypes: Record<never, never>;
+	};
+};
+
+type PublicSchema = Database["public"];
+
+export type Tables<T extends keyof PublicSchema["Tables"]> =
+	PublicSchema["Tables"][T]["Row"];
+
+export type TablesInsert<T extends keyof PublicSchema["Tables"]> =
+	PublicSchema["Tables"][T]["Insert"];
+
+export type TablesUpdate<T extends keyof PublicSchema["Tables"]> =
+	PublicSchema["Tables"][T]["Update"];

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,12 +1,13 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
+import type { Database } from "./database.types";
 
 export async function updateSession(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({
 		request,
 	});
 
-	const supabase = createServerClient(
+	const supabase = createServerClient<Database>(
 		// biome-ignore lint/style/noNonNullAssertion: env vars are required at runtime
 		process.env.NEXT_PUBLIC_SUPABASE_URL!,
 		// biome-ignore lint/style/noNonNullAssertion: env vars are required at runtime

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,10 +1,11 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import type { Database } from "./database.types";
 
 export async function createClient() {
 	const cookieStore = await cookies();
 
-	return createServerClient(
+	return createServerClient<Database>(
 		// biome-ignore lint/style/noNonNullAssertion: env vars are required at runtime
 		process.env.NEXT_PUBLIC_SUPABASE_URL!,
 		// biome-ignore lint/style/noNonNullAssertion: env vars are required at runtime

--- a/supabase/migrations/20260612000000_create_lobbies.sql
+++ b/supabase/migrations/20260612000000_create_lobbies.sql
@@ -59,3 +59,23 @@ create policy "ロビーは誰でも更新できる"
     to anon, authenticated
     using (true)
     with check (true);
+
+-- 列レベルの権限制御
+-- RLS ポリシーは行単位の制御のみで、書き換え可能なカラムは制限できない。
+-- anon キーを持つクライアントが PostgREST に直接リクエストを送って他人のロビーの
+-- lobby_name / is_private などを改ざんしたり、member_count に不正な初期値で
+-- 作成したりするのを防ぐため、操作可能なカラムを GRANT で明示的に限定する。
+-- （config.toml の auto_expose 既定が false 化されるため、明示 GRANT は動作上も必要）
+revoke all on public.lobbies from anon, authenticated;
+
+-- 一覧・詳細の閲覧
+grant select on public.lobbies to anon, authenticated;
+
+-- 作成時にクライアントが指定するカラムのみ INSERT を許可
+-- （member_count / last_activity_at / created_at / lobby_id はデフォルト値に任せる）
+grant insert (lobby_name, start_time, study_min, break_min, is_private, is_in_school)
+    on public.lobbies to anon, authenticated;
+
+-- 参加・退出時の人数更新（join-lobby / leave-lobby）のみ UPDATE を許可
+grant update (member_count, last_activity_at)
+    on public.lobbies to anon, authenticated;

--- a/supabase/migrations/20260612000000_create_lobbies.sql
+++ b/supabase/migrations/20260612000000_create_lobbies.sql
@@ -1,0 +1,61 @@
+-- ロビー（勉強部屋）テーブルの作成
+-- メンバー一覧・チャットは Supabase Realtime の presence / broadcast で扱うため
+-- 永続化するのはロビー本体のみ。
+
+create table if not exists public.lobbies (
+    lobby_id uuid primary key default gen_random_uuid(),
+    -- ロビー名（schemas/index.ts の lobbyNameSchema に対応: 2〜15文字）
+    lobby_name text not null,
+    -- 勉強開始時刻
+    start_time timestamptz not null,
+    -- 勉強時間（分）（studyMinSchema に対応: 5〜60分）
+    study_min smallint not null,
+    -- 休憩時間（分）（breakMinSchema に対応: 1〜15分）
+    break_min smallint not null,
+    -- 非公開フラグ
+    is_private boolean not null default false,
+    -- 校内限定フラグ
+    is_in_school boolean not null default false,
+    -- 現在の参加人数
+    member_count integer not null default 0,
+    -- 最終アクティビティ時刻（参加・退出時に更新）
+    last_activity_at timestamptz not null default now(),
+    -- 作成時刻（一覧の並び替えに使用）
+    created_at timestamptz not null default now(),
+
+    constraint lobbies_lobby_name_length check (char_length(lobby_name) between 2 and 15),
+    constraint lobbies_study_min_range check (study_min between 5 and 60),
+    constraint lobbies_break_min_range check (break_min between 1 and 15),
+    constraint lobbies_member_count_non_negative check (member_count >= 0)
+);
+
+-- 一覧取得（get-lobbies.ts）でよく使う絞り込み・並び替え向けのインデックス
+create index if not exists lobbies_is_private_created_at_idx
+    on public.lobbies (is_private, created_at desc);
+
+create index if not exists lobbies_is_in_school_idx
+    on public.lobbies (is_in_school);
+
+-- Row Level Security
+-- アプリはブラウザ・サーバーともに publishable（anon）キーでアクセスし、
+-- ロビー操作に認証チェックを設けていないため、anon / authenticated に許可する。
+alter table public.lobbies enable row level security;
+
+create policy "ロビーは誰でも閲覧できる"
+    on public.lobbies
+    for select
+    to anon, authenticated
+    using (true);
+
+create policy "ロビーは誰でも作成できる"
+    on public.lobbies
+    for insert
+    to anon, authenticated
+    with check (true);
+
+create policy "ロビーは誰でも更新できる"
+    on public.lobbies
+    for update
+    to anon, authenticated
+    using (true)
+    with check (true);


### PR DESCRIPTION
## Summary

This PR establishes the Supabase database schema and TypeScript type definitions for the lobbies (study rooms) feature. It includes the migration to create the `lobbies` table with appropriate constraints and indexes, along with auto-generated type definitions for type-safe database operations.

## Key Changes

- **Database Schema Migration** (`supabase/migrations/20260612000000_create_lobbies.sql`)
  - Created `lobbies` table with columns for lobby metadata (name, timing, duration settings, privacy flags, member count, activity tracking)
  - Added constraints to enforce business rules (lobby name length 2-15 chars, study time 5-60 min, break time 1-15 min, non-negative member count)
  - Created indexes on `(is_private, created_at desc)` and `(is_in_school)` to optimize the lobbies list retrieval query
  - Enabled Row Level Security with permissive policies allowing anonymous and authenticated users to select, insert, and update lobbies (matching the app's current auth model)

- **TypeScript Type Definitions** (`src/lib/supabase/database.types.ts`)
  - Generated type definitions for the `lobbies` table with `Row`, `Insert`, and `Update` variants
  - Exported utility types (`Tables`, `TablesInsert`, `TablesUpdate`) for convenient type access throughout the codebase

- **Supabase Client Type Safety**
  - Updated `src/lib/supabase/client.ts`, `src/lib/supabase/middleware.ts`, and `src/lib/supabase/server.ts` to use the `Database` type generic parameter
  - This enables full TypeScript type checking for all database queries and mutations

## Implementation Details

- The migration includes Japanese comments documenting the schema design rationale (e.g., member list and chat are handled via Supabase Realtime presence/broadcast, only the lobby itself is persisted)
- RLS policies are intentionally permissive since the app currently uses the publishable (anon) key without authentication checks on lobby operations
- The `last_activity_at` field is designed to track participation changes for potential future features like inactive lobby cleanup

https://claude.ai/code/session_01LEC7evdDKENf8FzXkgvPXh